### PR TITLE
Adding AWS_SESSION_TOKEN to Options interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ With promise
 var options = new Options(
   /* accessKey    */ 'your key',
   /* secretKey    */ 'your key2',
+  /* sessionToken */ 'your token',
   /* currentWorkingDirectory */ null
 );
 
@@ -96,6 +97,7 @@ import { Aws, Options } from 'aws-cli-js';
 const options = new Options(
   /* accessKey    */ 'your key',
   /* secretKey    */ 'your key2',
+  /* sessionToken */ 'your token',
   /* currentWorkingDirectory */ null
 );
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
   "accessKeyId": "keyid",
-  "secretAccessKey": "secret"
+  "secretAccessKey": "secret",
+  "sessionToken": "token"
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -15,6 +15,7 @@ test('aws-cli-js', t => {
     const options = new Options(
       /* accessKey    */ config.accessKeyId,
       /* secretKey    */ config.secretAccessKey,
+      /* sessionToken */ config.sessionToken,
       /* currentWorkingDirectory */ null
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ export class Aws {
         env['AWS_SECRET_ACCESS_KEY'] = aws.options.secretKey;
       }
 
+      if (aws.options.sessionToken) {
+        env['AWS_SESSION_TOKEN'] = aws.options.sessionToken;
+      }
+
       let execOptions = {
         cwd: aws.options.currentWorkingDirectory,
         env: env,
@@ -89,6 +93,7 @@ export class Aws {
 export interface IOptions {
   accessKey?: string;
   secretKey?: string;
+  sessionToken?: string;
   currentWorkingDirectory?: string;
 }
 
@@ -96,6 +101,7 @@ export class Options implements IOptions {
   public constructor(
     public accessKey?: string,
     public secretKey?: string,
+    public sessionToken?: string,
     public currentWorkingDirectory?: string) { }
 }
 


### PR DESCRIPTION
Ran into an instance where running the debugger in VS Code (and its differing ENV variables in powershell) could not execute aws commands.   Allowing the passthrough of the session token addressed the issue.  parameter marked as optional to allow backwards compatibility.  updated MD